### PR TITLE
Ruby version 'major.minor'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.5
+        ruby-version: 2.6
     - name: Restore Bundler cache
       id: cache
       uses: actions/cache@v1


### PR DESCRIPTION
With ruby version 2.6.5 or another with x.x.x I get the error Version 2.x.x not found.