### PR TITLE
feat: add option to set RSA key in env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Environment where deploy is to be performed to. E.g. "production", "staging". De
 **Required** Symmetric key to decrypt private RSA key. Must be a string.
 
 ### `enc_rsa_key_pth`
-**Required** Path to the encrypted key. Default `"config/deploy_id_rsa_enc"`.
+Path to the encrypted key. Default `"config/deploy_id_rsa_enc"`. You have to use either `enc_rsa_key_pth` or `enc_rsa_key_val`.
+
+### `enc_rsa_key_val`
+Contents of the encrypted key. Best to use as repository secret. You have to use either `enc_rsa_key_pth` or `enc_rsa_key_val`.
 
 ### `working-directory`
 The directory from which to run the deploy commands, including `bundle install`.

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,11 @@ inputs:
     required: true
   enc_rsa_key_pth:
     description: 'Path to SSH private key encrypted with deploy_key'
-    required: true
+    required: false
     default: 'config/deploy_id_rsa_enc'
+  enc_rsa_key_val:
+    description: 'Value of the SSH private key encrypted with deploy_key'
+    required: false
   working-directory:
     description: 'The directory from which to run the deploy command'
     required: false

--- a/lib/run.js
+++ b/lib/run.js
@@ -17,6 +17,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = require("@actions/core");
 const io = require("@actions/io");
 const toolrunner = require("@actions/exec/lib/toolrunner");
+const fs = require('fs');
 
 function install_deps(options) {
   return __awaiter(this, void 0, void 0, function* () {
@@ -79,16 +80,25 @@ function run() {
     const target = core.getInput('target');
     const deploy_key = core.getInput('deploy_key');
     const enc_rsa_key_pth = core.getInput('enc_rsa_key_pth');
+    const enc_rsa_key_val = core.getInput('enc_rsa_key_val');
     const working_directory = core.getInput('working-directory');
 
     if (!deploy_key) {
       core.setFailed('No deploy key given');
     }
 
-    // TODO: also check that the file exists
-    if (!enc_rsa_key_pth) {
-      core.setFailed('Encrypted RSA private key undefined');
+    try {
+      if (!fs.existsSync(enc_rsa_key_pth) && !enc_rsa_key_val) {
+        core.setFailed('Encrypted RSA private key file or value does not exist.');
+      }
+
+      if (enc_rsa_key_val) {
+        fs.writeFileSync(enc_rsa_key_pth, enc_rsa_key_val);
+      }
+    } catch(error) {
+      core.setFailed(error);
     }
+
     const options = working_directory ? { cwd: working_directory, } : {};
     yield install_deps(options);
     yield decrypt_key(deploy_key, enc_rsa_key_pth, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actions",
-    "version": "0.0.0",
+    "version": "0.0.1",
     "description": "Node modules for capistrano actions",
     "author": "Vladimir Miloserdov",
     "license": "MIT",


### PR DESCRIPTION
It's not necessarily the best option to keep the RSA key file in the repository itself.

Added an option for the RSA key to be set as a build parameter from env vars / secrets.