### PR TITLE
Bundle install shouldn’t be a responsibility of this action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Github deploy action for Capistrano. Use this action to automate your capistrano deployment process.
 
 ## Dependencies
-Ruby should be installed with official ruby action (https://github.com/actions/setup-ruby)
+This action expects Ruby to be installed along with Capistrano, see below for a [basic workflow example](#workflow-example) that uses [ruby/setup-ruby](https://github.com/ruby/setup-ruby).
 
 ## Inputs
 ### `target`
-Environment where deploy is to be performed to. E.g. "production", "staging". Default value is empty
+Environment where deploy is to be performed to. E.g. "production", "staging". Default value is empty.
 
 ### `deploy_key`
 **Required** Symmetric key to decrypt private RSA key. Must be a string.
@@ -19,10 +19,6 @@ Contents of the encrypted key. Best to use as repository secret. You have to use
 
 ### `working-directory`
 The directory from which to run the deploy commands, including `bundle install`.
-
-### `bundler_version`
-
-The version of Bundler to install before running the bundle-command. By default Bundler v1.17.3 is used.
 
 ## Outputs
 No outputs
@@ -59,19 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-    - name: Restore Bundler cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-bundle-
-    - uses: miloserdow/capistrano-deploy@v2.1
+        bundler-cache: true
+    - uses: miloserdow/capistrano-deploy@v2
       with:
         target: production
         deploy_key: ${{ secrets.DEPLOY_ENC_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,6 @@ branding:
   icon: 'arrow-right-circle'
   color: 'black'
 inputs:
-  bundler_version:
-    default: '1.17.3'
-    description: 'The version of Bundler to install before running the bundle-command'
-    required: true
   target:  # string
     description: 'Environment where deploy is to be performed to'
     required: false # if no param is given, default cap target will be selected

--- a/lib/run.js
+++ b/lib/run.js
@@ -19,24 +19,6 @@ const io = require("@actions/io");
 const toolrunner = require("@actions/exec/lib/toolrunner");
 const fs = require('fs');
 
-function install_deps(options) {
-  return __awaiter(this, void 0, void 0, function* () {
-    const bundlerVersion = core.getInput('bundler_version');
-
-    let runner = null;
-    runner = new toolrunner.ToolRunner('gem', ['install', `bundler:${bundlerVersion}`, '--no-document'], options);
-    yield runner.exec();
-
-    let runner2 = null;
-    runner2 = new toolrunner.ToolRunner(
-      'bundle',
-      ['install', '--deployment', '--jobs=4', '--retry=3', '--without=production test'],
-      options
-    );
-    yield runner2.exec();
-  });
-}
-
 function decrypt_key(deploy_key, enc_rsa_key_pth, options) {
   return __awaiter(this, void 0, void 0, function* () {
     // Create directory if it doesn't yet exists
@@ -102,7 +84,6 @@ function run() {
     }
 
     const options = working_directory ? { cwd: working_directory, } : {};
-    yield install_deps(options);
     yield decrypt_key(deploy_key, enc_rsa_key_pth, options);
     yield deploy(target, options);
   });


### PR DESCRIPTION
I think that as well as expecting Ruby to be installed this action should expect that the consuming workflow installs Capistrano - probably via `bundle install` but possibly just `gem install capistrano`. There are two open issues (#11 and #14) related to bundler (and a number of closed issues) that would be solved by removing the responsibility of `bundle install` from this action.

The simplest way that I know of to achieve this (and the speediest) is to use [ruby/setup-ruby](https://github.com/ruby/setup-ruby) and let it deal with both bundling and caching - I've updated the workflow example to use this action.

This is a breaking change because many existing users of this action will be missing their own `bundle install` step.
