### PR TITLE
Avoiding an "obsolete key derivation" message when deploying

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -30,7 +30,7 @@ function decrypt_key(deploy_key, enc_rsa_key_pth, options) {
 
     const runner = new toolrunner.ToolRunner('openssl',
         ['enc', '-d', '-aes-256-cbc', '-md', 'sha512', '-salt', '-in',
-         enc_rsa_key_pth, '-out', 'config/deploy_id_rsa', '-k', deploy_key, '-a'], options);
+         enc_rsa_key_pth, '-out', 'config/deploy_id_rsa', '-k', deploy_key, '-a', 'pbkdf2'], options);
     yield runner.exec();
 
     const runner1 = new toolrunner.ToolRunner('chmod', ['0600', 'config/deploy_id_rsa'], options);


### PR DESCRIPTION
Add 'pbkdf2' arguments to avoid the following message during deployment

```
/usr/bin/openssl enc -d -aes-256-cbc -md sha512 -salt -in config/deploy_id_rsa_enc -out config/deploy_id_rsa -k *** -a
*** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
bad decrypt
```