### PR TITLE
Add the hyphen for the "pbkdf2" argument

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -30,7 +30,7 @@ function decrypt_key(deploy_key, enc_rsa_key_pth, options) {
 
     const runner = new toolrunner.ToolRunner('openssl',
         ['enc', '-d', '-aes-256-cbc', '-md', 'sha512', '-salt', '-in',
-         enc_rsa_key_pth, '-out', 'config/deploy_id_rsa', '-k', deploy_key, '-a', 'pbkdf2'], options);
+         enc_rsa_key_pth, '-out', 'config/deploy_id_rsa', '-k', deploy_key, '-a', '-pbkdf2'], options);
     yield runner.exec();
 
     const runner1 = new toolrunner.ToolRunner('chmod', ['0600', 'config/deploy_id_rsa'], options);


### PR DESCRIPTION
Missing to add the hyphen of the argument "pbkdf2"

[Print Imgur](https://i.imgur.com/waP6rJO.png)