### PR TITLE
Updated nodejs version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/run.js'


### PR DESCRIPTION
# Description

Since september the 22th, [actions will run on node1](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)6 instead of node12. This PR simply update the node version in the `action.yml` file